### PR TITLE
instrument sub-archives recursively

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <properties>
 
         <!-- Versioning -->
-        <version.arquillian_core>1.0.0.CR2</version.arquillian_core>
+        <version.arquillian_core>1.0.0.Final-SNAPSHOT</version.arquillian_core>
         <version.arquillian_jboss>1.0.0.CR1</version.arquillian_jboss>
         <version.jacoco>0.5.3.201107060350</version.jacoco>
         <version.asm>3.2</version.asm>
@@ -157,6 +157,28 @@
             </dependencies>
             <build>
                 <plugins>
+                    <plugin>
+                        <!-- Copy the test-classes to classes/ so we get reports from them also -->
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <version>2.5</version>
+                        <executions>
+                            <execution>
+                                <id>jacoco-copy-test-classes</id>
+                                <phase>process-test-classes</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${basedir}/target/classes</outputDirectory>
+                                    <resources>          
+                                        <resource>
+                                            <directory>target/test-classes</directory>
+                                        </resource>
+                                    </resources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>

--- a/src/test/java/org/jboss/arquillian/extension/jacoco/test/integration/SubArchiveTestCase.java
+++ b/src/test/java/org/jboss/arquillian/extension/jacoco/test/integration/SubArchiveTestCase.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.extension.jacoco.test.integration;
+
+import javax.ejb.EJB;
+
+import junit.framework.Assert;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.extension.jacoco.test.CoverageBean;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * SubArchiveTestCase
+ *
+ * @author <a href="mailto:maschmid@redhat.com">Marek Schmidt</a>
+ */
+@RunWith(Arquillian.class)
+public class SubArchiveTestCase
+{
+   @Deployment
+   public static WebArchive createDeployment() 
+   {
+      return ShrinkWrap.create(WebArchive.class, "test.war")
+                  .addAsLibrary(
+                          ShrinkWrap.create(JavaArchive.class, "test.jar")
+                              .addClasses(CoverageBean.class));
+   }
+   
+   @EJB
+   private CoverageBean bean;
+   
+   @Test
+   public void shouldBeAbleToGenerateSomeTestCoverage() throws Exception
+   {
+      Assert.assertNotNull(bean);      
+      bean.test(false);
+   }
+}


### PR DESCRIPTION
ARQ-599 ApplicationArchiveInstrumenter should also instrument classes inside JARs

also, modify the -Pintegration profile to copy the test-classes to classes, so the generated jacoco report contains those classes too... makes the test results much easier to interpret.
