### PR TITLE
Updated to JaCoCo 0.7.1.201405082137 with Java 8 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>13</version>
+        <version>14</version>
         <relativePath />
     </parent>
 
@@ -22,11 +22,11 @@
     <!-- Properties -->
     <properties>
         <!-- Versioning -->
-        <version.arquillian_core>1.1.3.Final</version.arquillian_core>
-        <version.jacoco>0.6.4.201312101107</version.jacoco>
+        <version.arquillian_core>1.1.5.Final</version.arquillian_core>
+        <version.jacoco>0.7.1.201405082137</version.jacoco>
 
         <!-- test -->
-        <version.wildfly>8.0.0.Final</version.wildfly>
+        <version.wildfly>8.1.0.Final</version.wildfly>
         <version.cdi-api>1.1</version.cdi-api>
         <version.ejb3>1.0.2.Final</version.ejb3>
 

--- a/src/main/java/org/jboss/arquillian/extension/jacoco/container/ArquillianRuntime.java
+++ b/src/main/java/org/jboss/arquillian/extension/jacoco/container/ArquillianRuntime.java
@@ -197,10 +197,4 @@ public class ArquillianRuntime implements IRuntime
       mv.visitMethodInsn(Opcodes.INVOKESTATIC, "java/lang/Integer", "valueOf", "(I)Ljava/lang/Integer;");
       mv.visitInsn(Opcodes.AASTORE);
    }
-
-   @Override
-   public void disconnect(Class<?> type) throws Exception
-   {
-      throw new UnsupportedOperationException();
-   }
 }


### PR DESCRIPTION
Updated to the latest JaCoCo version which supports Java 8.
I've tested with Arquillian Core 1.1.5 and WildFly 8.1.0.Final.
