### PR TITLE
Synchronize dependencies for 8.2.0.Final & Java 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,12 +23,12 @@
     <properties>
         <!-- Versioning -->
         <version.arquillian_core>1.1.5.Final</version.arquillian_core>
-        <version.jacoco>0.7.1.201405082137</version.jacoco>
+        <version.jacoco>0.7.2.201409121644</version.jacoco>
 
         <!-- test -->
-        <version.wildfly>8.1.0.Final</version.wildfly>
-        <version.cdi-api>1.1</version.cdi-api>
-        <version.ejb3>1.0.2.Final</version.ejb3>
+        <version.wildfly>8.2.0.Final</version.wildfly>
+        <version.cdi-api>1.2</version.cdi-api>
+        <version.ejb3>1.0.0.Final</version.ejb3>
 
         <!-- override from parent -->
         <maven.compiler.argument.target>1.5</maven.compiler.argument.target>
@@ -45,7 +45,7 @@
                 <version>${version.arquillian_core}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>            
+            </dependency>
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-build</artifactId>
@@ -113,7 +113,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.ejb</groupId>
-            <artifactId>jboss-ejb-api_3.1_spec</artifactId>
+            <artifactId>jboss-ejb-api_3.2_spec</artifactId>
             <version>${version.ejb3}</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
Bump to WildFly 8.2.0.Final
Upgrade to Jacoco 0.7.2 for Lambda support
WFLY 8.2.0.Final uses Weld 2.2.6 => CDI 1.2
WFLY 8.2.0.Final uses EJB 3.2