### PR TITLE
Issue#26: Updates dependencies to the latest.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,8 @@
     <!-- Properties -->
     <properties>
         <!-- Versioning -->
-        <version.arquillian_core>1.1.5.Final</version.arquillian_core>
-        <version.jacoco>0.7.4.201502262128</version.jacoco>
+        <version.arquillian_core>1.1.11.Final</version.arquillian_core>
+        <version.jacoco>0.7.7.201606060606</version.jacoco>
 
         <!-- test -->
         <version.wildfly>8.2.0.Final</version.wildfly>

--- a/src/test/java/org/jboss/arquillian/extension/jacoco/test/integration/IncludeExcludeTestCase.java
+++ b/src/test/java/org/jboss/arquillian/extension/jacoco/test/integration/IncludeExcludeTestCase.java
@@ -18,8 +18,6 @@ package org.jboss.arquillian.extension.jacoco.test.integration;
 
 import javax.ejb.EJB;
 
-import junit.framework.Assert;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.extension.jacoco.test.ImplicitNoCoverageBean;
 import org.jboss.arquillian.extension.jacoco.test.excluded.ExplicitNoCoverageBean;
@@ -27,6 +25,7 @@ import org.jboss.arquillian.extension.jacoco.test.included.CoverageBean;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 

--- a/src/test/java/org/jboss/arquillian/extension/jacoco/test/integration/JacocoInegrationTestCase.java
+++ b/src/test/java/org/jboss/arquillian/extension/jacoco/test/integration/JacocoInegrationTestCase.java
@@ -18,13 +18,12 @@ package org.jboss.arquillian.extension.jacoco.test.integration;
 
 import javax.ejb.EJB;
 
-import junit.framework.Assert;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.extension.jacoco.test.included.CoverageBean;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 

--- a/src/test/java/org/jboss/arquillian/extension/jacoco/test/integration/SubArchiveTestCase.java
+++ b/src/test/java/org/jboss/arquillian/extension/jacoco/test/integration/SubArchiveTestCase.java
@@ -18,14 +18,13 @@ package org.jboss.arquillian.extension.jacoco.test.integration;
 
 import javax.ejb.EJB;
 
-import junit.framework.Assert;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.extension.jacoco.test.included.SubCoverageBean;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 

--- a/src/test/java/org/jboss/arquillian/extension/jacoco/test/unit/InstrumentTestCase.java
+++ b/src/test/java/org/jboss/arquillian/extension/jacoco/test/unit/InstrumentTestCase.java
@@ -22,8 +22,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.jar.Manifest;
 
-import junit.framework.Assert;
-
 import org.jacoco.core.analysis.Analyzer;
 import org.jacoco.core.analysis.CoverageBuilder;
 import org.jacoco.core.analysis.IClassCoverage;
@@ -46,6 +44,7 @@ import org.jboss.shrinkwrap.resolver.api.maven.PomEquippedResolveStage;
 import org.jboss.shrinkwrap.resolver.api.maven.ScopeType;
 import org.jboss.shrinkwrap.resolver.api.maven.coordinate.MavenCoordinate;
 import org.junit.Ignore;
+import org.junit.Assert;
 import org.junit.Test;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.util.TraceClassVisitor;

--- a/src/test/java/org/jboss/arquillian/extension/jacoco/test/verify/VerifyIntegrationCoverageTestCase.java
+++ b/src/test/java/org/jboss/arquillian/extension/jacoco/test/verify/VerifyIntegrationCoverageTestCase.java
@@ -1,12 +1,11 @@
 package org.jboss.arquillian.extension.jacoco.test.verify;
 
-import junit.framework.Assert;
-
 import org.jboss.arquillian.extension.jacoco.test.ImplicitNoCoverageBean;
 import org.jboss.arquillian.extension.jacoco.test.excluded.ExplicitNoCoverageBean;
 import org.jboss.arquillian.extension.jacoco.test.included.CoverageBean;
 import org.jboss.arquillian.extension.jacoco.test.included.ImportedSubArchive;
 import org.jboss.arquillian.extension.jacoco.test.included.SubCoverageBean;
+import org.junit.Assert;
 import org.junit.Test;
 
 /*


### PR DESCRIPTION
#### Short description of what this resolves:
Updates JaCoCo and Arquillian Core dependencies to the latest.

#### Changes proposed in this pull request:

- Updates Arquillian Core to 1.1.11.Final
- Update JaCoCo to 0.7.7.201606060606
- Change deprecated junit assertions from junit.framework.Assert to org.junit.Assert

**Fixes**: #26 
