### PR TITLE
Fix #34 by checking java.lang.UnknownError for $jacocoAccess

### DIFF
--- a/src/main/java/org/jboss/arquillian/extension/jacoco/client/CoverageDataReceiver.java
+++ b/src/main/java/org/jboss/arquillian/extension/jacoco/client/CoverageDataReceiver.java
@@ -34,7 +34,13 @@ public class CoverageDataReceiver {
     }
 
     private void copyToAgentExecutionStore(ExecutionDataStore dataStore) throws Exception {
-        Field f = UUID.class.getDeclaredField("$jacocoAccess");
+        Field f = null;
+        try {
+            f = UUID.class.getDeclaredField("$jacocoAccess");
+        } catch(Exception e) {
+            f = UnknownError.class.getDeclaredField("$jacocoAccess");
+        }
+
         Object executor = f.get(null);
 
         Method m = executor.getClass().getDeclaredMethod("getProbes", Object[].class);

--- a/src/main/java/org/jboss/arquillian/extension/jacoco/client/configuration/JaCoCoConfiguration.java
+++ b/src/main/java/org/jboss/arquillian/extension/jacoco/client/configuration/JaCoCoConfiguration.java
@@ -83,8 +83,12 @@ public class JaCoCoConfiguration {
     }
 
     public static boolean isJacocoAgentActive() {
+        return hasClassJacocoAccessField(UUID.class) || hasClassJacocoAccessField(UnknownError.class);
+    }
+
+    private static boolean hasClassJacocoAccessField(Class<?> clazz) {
         try {
-            UUID.class.getDeclaredField("$jacocoAccess");
+            clazz.getDeclaredField("$jacocoAccess");
         } catch (Exception e) {
             return false;
         }


### PR DESCRIPTION
#### Short description of what this resolves:
JaCoCo 0.8.0 switched from instrumenting java.util.UUID to instrumenting java.lang.UnknownError.

#### Changes proposed in this pull request:
Check java.lang.UnknownError (in addition to java.util.UUID) for $jacocoAccess

**Fixes**: #34