### PR TITLE
build(deps): bumps Jacoco to 0.8.2

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -17,8 +17,8 @@ Set the versions to use:
 ----
 ...
 <properties>
-   <version.jacoco>0.7.8</version.jacoco>
-   <version.arquillian_jacoco>1.0.0.Alpha9</version.arquillian_jacoco>
+   <version.jacoco>0.8.2</version.jacoco>
+   <version.arquillian_jacoco>1.0.0.Final-SNAPSHOT</version.arquillian_jacoco>
 </properties>
 ...
 ----

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>org.jboss.arquillian.extension</groupId>
   <artifactId>arquillian-jacoco</artifactId>
-  <version>1.0.0-kifj-1</version>
+  <version>1.0.0.Final-SNAPSHOT</version>
   <name>Arquillian Extension Jacoco</name>
   <description>Jacoco integration to add code coverage to Arquillian</description>
 
@@ -47,7 +47,7 @@
     <connection>scm:git:git://git@github.com:arquillian/arquillian-extension-jacoco.git</connection>
     <developerConnection>scm:git:ssh://github.com/arquillian/arquillian-extension-jacoco.git</developerConnection>
     <url>git://github.com/arquillian/arquillian-extension-jacoco.git</url>
-    <tag>arquillian-jacoco-1.0.0-kifj-1</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -1,20 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <!-- Parent -->
   <parent>
     <groupId>org.jboss</groupId>
     <artifactId>jboss-parent</artifactId>
     <version>28</version>
-    <relativePath/>
+    <relativePath />
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.jboss.arquillian.extension</groupId>
   <artifactId>arquillian-jacoco</artifactId>
-  <version>1.0.0.Final-SNAPSHOT</version>
+  <version>1.0.0-kifj-1</version>
   <name>Arquillian Extension Jacoco</name>
   <description>Jacoco integration to add code coverage to Arquillian</description>
 
@@ -48,7 +47,7 @@
     <connection>scm:git:git://git@github.com:arquillian/arquillian-extension-jacoco.git</connection>
     <developerConnection>scm:git:ssh://github.com/arquillian/arquillian-extension-jacoco.git</developerConnection>
     <url>git://github.com/arquillian/arquillian-extension-jacoco.git</url>
-    <tag>HEAD</tag>
+    <tag>arquillian-jacoco-1.0.0-kifj-1</tag>
   </scm>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jboss</groupId>
     <artifactId>jboss-parent</artifactId>
-    <version>22</version>
+    <version>28</version>
     <relativePath/>
   </parent>
 
@@ -23,17 +23,16 @@
     <version.jacoco>0.8.2</version.jacoco>
 
     <version.wildfly>14.0.0.Final</version.wildfly>
-    <version.cdi-api>1.2</version.cdi-api>
+    <version.wildfly.arquillian>2.1.1.Final</version.wildfly.arquillian>
+    <version.cdi-api>2.0</version.cdi-api>
 
-    <version.ejb3>1.0.0.Final</version.ejb3>
+    <version.ejb3>1.0.1.Final</version.ejb3>
 
     <version.mockito>1.10.19</version.mockito>
     <version.assertj>2.6.0</version.assertj>
 
     <!-- Overridden from parent -->
-    <jdk.min.version>1.8</jdk.min.version>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.compiler.source>1.8</maven.compiler.source>
+    <jdk.min.version>1.5</jdk.min.version>
 
     <wildfly_home>${project.build.directory}/wildfly-${version.wildfly}</wildfly_home>
   </properties>
@@ -178,7 +177,7 @@
         <dependency>
           <groupId>org.wildfly.arquillian</groupId>
           <artifactId>wildfly-arquillian-container-managed</artifactId>
-          <version>2.1.1.Final</version>
+          <version>${version.wildfly.arquillian}</version>
           <scope>test</scope>
         </dependency>
       </dependencies>
@@ -218,7 +217,7 @@
         <dependency>
           <groupId>org.wildfly.arquillian</groupId>
           <artifactId>wildfly-arquillian-container-remote</artifactId>
-          <version>2.1.1.Final</version>
+          <version>${version.wildfly.arquillian}</version>
           <scope>test</scope>
         </dependency>
       </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -19,10 +19,10 @@
   <description>Jacoco integration to add code coverage to Arquillian</description>
 
   <properties>
-    <version.arquillian_core>1.1.13.Final</version.arquillian_core>
-    <version.jacoco>0.7.9</version.jacoco>
+    <version.arquillian_core>1.4.0.Final</version.arquillian_core>
+    <version.jacoco>0.8.2</version.jacoco>
 
-    <version.wildfly>8.2.1.Final</version.wildfly>
+    <version.wildfly>14.0.0.Final</version.wildfly>
     <version.cdi-api>1.2</version.cdi-api>
 
     <version.ejb3>1.0.0.Final</version.ejb3>
@@ -31,9 +31,9 @@
     <version.assertj>2.6.0</version.assertj>
 
     <!-- Overridden from parent -->
-    <jdk.min.version>1.5</jdk.min.version>
-    <maven.compiler.target>1.5</maven.compiler.target>
-    <maven.compiler.source>1.5</maven.compiler.source>
+    <jdk.min.version>1.8</jdk.min.version>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
 
     <wildfly_home>${project.build.directory}/wildfly-${version.wildfly}</wildfly_home>
   </properties>
@@ -144,6 +144,12 @@
       <version>${version.assertj}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-util</artifactId>
+      <version>6.2.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <profiles>
@@ -170,9 +176,9 @@
       </activation>
       <dependencies>
         <dependency>
-          <groupId>org.wildfly</groupId>
+          <groupId>org.wildfly.arquillian</groupId>
           <artifactId>wildfly-arquillian-container-managed</artifactId>
-          <version>${version.wildfly}</version>
+          <version>2.1.1.Final</version>
           <scope>test</scope>
         </dependency>
       </dependencies>
@@ -210,9 +216,9 @@
       <id>remote</id>
       <dependencies>
         <dependency>
-          <groupId>org.wildfly</groupId>
+          <groupId>org.wildfly.arquillian</groupId>
           <artifactId>wildfly-arquillian-container-remote</artifactId>
-          <version>${version.wildfly}</version>
+          <version>2.1.1.Final</version>
           <scope>test</scope>
         </dependency>
       </dependencies>

--- a/src/main/java/org/jboss/arquillian/extension/jacoco/client/CoverageDataReceiver.java
+++ b/src/main/java/org/jboss/arquillian/extension/jacoco/client/CoverageDataReceiver.java
@@ -34,7 +34,13 @@ public class CoverageDataReceiver {
     }
 
     private void copyToAgentExecutionStore(ExecutionDataStore dataStore) throws Exception {
-        Field f = UUID.class.getDeclaredField("$jacocoAccess");
+        Field f = null;
+        try {
+            f = UUID.class.getDeclaredField("$jacocoAccess");
+        } catch(Exception e) {
+            f = UnknownError.class.getDeclaredField("$jacocoAccess");
+        }
+
         Object executor = f.get(null);
 
         Method m = executor.getClass().getDeclaredMethod("getProbes", Object[].class);

--- a/src/main/java/org/jboss/arquillian/extension/jacoco/client/CoverageDataReceiver.java
+++ b/src/main/java/org/jboss/arquillian/extension/jacoco/client/CoverageDataReceiver.java
@@ -37,7 +37,7 @@ public class CoverageDataReceiver {
         Field f = null;
         try {
             f = UUID.class.getDeclaredField("$jacocoAccess");
-        } catch(Exception e) {
+        } catch (Exception e) {
             f = UnknownError.class.getDeclaredField("$jacocoAccess");
         }
 

--- a/src/main/java/org/jboss/arquillian/extension/jacoco/client/JaCoCoApplicationArchiveProcessor.java
+++ b/src/main/java/org/jboss/arquillian/extension/jacoco/client/JaCoCoApplicationArchiveProcessor.java
@@ -31,7 +31,6 @@ import org.jboss.shrinkwrap.api.Archive;
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
  * @author <a href="mailto:lkrejci@redhat.com">Lukas Krejci</a>
  * @version $Revision: $
- * @Deployment.
  */
 public class JaCoCoApplicationArchiveProcessor implements ApplicationArchiveProcessor {
 

--- a/src/main/java/org/jboss/arquillian/extension/jacoco/client/configuration/JaCoCoConfiguration.java
+++ b/src/main/java/org/jboss/arquillian/extension/jacoco/client/configuration/JaCoCoConfiguration.java
@@ -83,8 +83,12 @@ public class JaCoCoConfiguration {
     }
 
     public static boolean isJacocoAgentActive() {
+        return hasClassJacocoAccessField(UUID.class) || hasClassJacocoAccessField(UnknownError.class);
+    }
+
+    private static boolean hasClassJacocoAccessField(Class<?> clazz) {
         try {
-            UUID.class.getDeclaredField("$jacocoAccess");
+            clazz.getDeclaredField("$jacocoAccess");
         } catch (Exception e) {
             return false;
         }

--- a/src/test/resources/arquillian.xml
+++ b/src/test/resources/arquillian.xml
@@ -8,8 +8,8 @@
 
   <container qualifier="wildfy" default="true">
     <configuration>
-      <property name="jbossHome">${env.test_container:target/wildfly-8.2.0.Final}</property>
-      <property name="javaVmArguments">-Xmx1024m -XX:PermSize=256m -XX:MaxPermSize=256m</property>
+      <property name="jbossHome">${env.test_container:target/wildfly-14.0.0.Final}</property>
+      <property name="javaVmArguments">-server -Xmx512m</property>
     </configuration>
   </container>
 


### PR DESCRIPTION
#### Short description of what this resolves:
- update to Jacoco 0.8.2 works for JDK 10 and 11

#### Changes proposed in this pull request:

- Java 1.8 is minimum requirement
- Wildfly 14.0.0.Final is used for testing
- Arquillian 1.4.0.Final is used as base
- Jacoco is upgraded to 0.8.2 

**Fixes**: #
- works with Java 11