### PR TITLE
Fix JaCoCo 0.8.3 on Java 9 and above

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: java
 jdk:
   - oraclejdk8
+  - oraclejdk11

--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,8 @@
     <version.jacoco>0.8.3</version.jacoco>
     <version.asm-util>7.0</version.asm-util> <!-- Should be aligned with ASM version JaCoCo is relying on to avoid failures in tests -->
 
-    <version.wildfly>14.0.0.Final</version.wildfly>
-    <version.wildfly.arquillian>2.1.1.Final</version.wildfly.arquillian>
+    <version.wildfly>16.0.0.Final</version.wildfly>
+    <version.wildfly.arquillian>2.2.0.Final</version.wildfly.arquillian>
     <version.cdi-api>2.0</version.cdi-api>
 
     <version.ejb3>1.0.1.Final</version.ejb3>

--- a/src/main/java/org/jboss/arquillian/extension/jacoco/client/CoverageDataReceiver.java
+++ b/src/main/java/org/jboss/arquillian/extension/jacoco/client/CoverageDataReceiver.java
@@ -38,7 +38,11 @@ public class CoverageDataReceiver {
         try {
             f = UUID.class.getDeclaredField("$jacocoAccess");
         } catch (Exception e) {
-            f = UnknownError.class.getDeclaredField("$jacocoAccess");
+            try {
+                f = UnknownError.class.getDeclaredField("$jacocoAccess");
+            } catch(Exception ex) {
+                f = Class.forName("java.lang.$JaCoCo").getDeclaredField("data");
+            }
         }
 
         Object executor = f.get(null);

--- a/src/main/java/org/jboss/arquillian/extension/jacoco/client/configuration/JaCoCoConfiguration.java
+++ b/src/main/java/org/jboss/arquillian/extension/jacoco/client/configuration/JaCoCoConfiguration.java
@@ -98,7 +98,7 @@ public class JaCoCoConfiguration {
     private static boolean hasClass(String className) {
         try {
             Class.forName(className);
-        } catch (Exception e) {
+        } catch (ClassNotFoundException e) {
             return false;
         }
         return true;

--- a/src/main/java/org/jboss/arquillian/extension/jacoco/client/configuration/JaCoCoConfiguration.java
+++ b/src/main/java/org/jboss/arquillian/extension/jacoco/client/configuration/JaCoCoConfiguration.java
@@ -83,12 +83,21 @@ public class JaCoCoConfiguration {
     }
 
     public static boolean isJacocoAgentActive() {
-        return hasClassJacocoAccessField(UUID.class) || hasClassJacocoAccessField(UnknownError.class);
+        return hasClassJacocoAccessField(UUID.class) || hasClassJacocoAccessField(UnknownError.class) || hasClass("java.lang.$JaCoCo");
     }
 
     private static boolean hasClassJacocoAccessField(Class<?> clazz) {
         try {
             clazz.getDeclaredField("$jacocoAccess");
+        } catch (Exception e) {
+            return false;
+        }
+        return true;
+    }
+
+    private static boolean hasClass(String className) {
+        try {
+            Class.forName(className);
         } catch (Exception e) {
             return false;
         }

--- a/src/test/resources/arquillian.xml
+++ b/src/test/resources/arquillian.xml
@@ -8,7 +8,7 @@
 
   <container qualifier="wildfy" default="true">
     <configuration>
-      <property name="jbossHome">${env.test_container:target/wildfly-14.0.0.Final}</property>
+      <property name="jbossHome">${env.test_container:target/wildfly-16.0.0.Final}</property>
       <property name="javaVmArguments">-server -Xmx512m</property>
     </configuration>
   </container>


### PR DESCRIPTION
#### Short description of what this resolves:
Starting from version 0.8.3 JaCoCo Java agent implementation uses the InjectedClassRuntime to define new class (named java.lang.$JaCoCo) in bootstrap class loader when running on JRE 9 and higher.

#### Changes proposed in this pull request:
Added a new case to JaCoCoConfiguration#isJacocoAgentActive 