### PR TITLE
build(travis): fix oraclejdk8 install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: java
 
-jdk:
-  - oraclejdk8
-  - oraclejdk11
+matrix:
+  include:
+  - jdk: oraclejdk8
+    dist: trusty    # see https://travis-ci.community/t/install-of-oracle-jdk-8-failing/3038/9
+  - jdk: oraclejdk11
+    dist: bionic
 
 before_install:
   - sed -i.bak -e 's|http://repo.maven.apache.org/maven2|https://repo.maven.apache.org/maven2|g' $HOME/.m2/settings.xml


### PR DESCRIPTION
Fixes:
```
install-jdk.sh 2019-09-17

Expected feature release number in range of 9 to 14, but got: 8

The command "~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"" failed and exited with 3 during .

Your build has been stopped.
```
The update to `bionic` for `oraclejdk11` is _not_ strictly needed but results in a more recent minor version of JDK11.