### PR TITLE
Getting Coverage Data from deployments created by Java 17 by updating to JaCoCo 0.8.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,8 @@
 
   <properties>
     <version.arquillian_core>1.6.0.Final</version.arquillian_core>
-    <version.jacoco>0.8.5</version.jacoco>
-    <version.asm-util>7.2</version.asm-util> <!-- Should be aligned with ASM version JaCoCo is relying on to avoid failures in tests -->
+    <version.jacoco>0.8.8</version.jacoco>
+    <version.asm-util>9.2</version.asm-util> <!-- Should be aligned with ASM version JaCoCo is relying on to avoid failures in tests -->
 
     <version.wildfly>16.0.0.Final</version.wildfly>
     <version.wildfly.arquillian>2.2.0.Final</version.wildfly.arquillian>


### PR DESCRIPTION
#### Short description of what this resolves:
Allows creation of code coverage reports on applications compiled against Java 17 by pumping JaCoCo to 0.8.8 (version with official JDK-17 support) and pumping the related asm version to 9.2.

#### Changes proposed in this pull request:
- Update JaCoCo version to 0.8.8
- Update ASM version to 9.2
